### PR TITLE
Fix comment referencing First_time

### DIFF
--- a/src/types/marathon.ts
+++ b/src/types/marathon.ts
@@ -10,7 +10,7 @@ export interface Location {
   country: string;
 }
 
-// define a variant type of special marks, like `PB`, `Hilly_course`, `Injury`, `World_major`, `First_race` etc. Each of these should have an optional description.
+// define a variant type of special marks, like `PB`, `Hilly_course`, `Injury`, `World_major`, `First_time` etc. Each of these should have an optional description.
 export type SpecialMarkType =
   | "First_time"
   | "PB"


### PR DESCRIPTION
## Summary
- fix documentation for SpecialMarkType to mention `First_time`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6844f48b81f88324a1c9ca5b20cf7a8f