### PR TITLE
Make website mobile-friendly with card-based layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,7 +65,7 @@ function App() {
               <h2 className="text-xl font-semibold text-gray-900 mb-4">
                 Upcoming Races ({upcomingRaces.length})
               </h2>
-              <div className="-mx-2 sm:mx-0">
+              <div>
                 <UpcomingRaces races={upcomingRaces} />
               </div>
             </div>
@@ -75,7 +75,7 @@ function App() {
             <h2 className="text-xl font-semibold text-gray-900 mb-4">
               Race History ({marathonResults.length})
             </h2>
-            <div className="-mx-2 sm:mx-0">
+            <div>
               <ResultsTable results={marathonResults} />
             </div>
           </div>

--- a/src/components/Bio.tsx
+++ b/src/components/Bio.tsx
@@ -12,7 +12,7 @@ function StravaIcon({ className }: { className?: string }) {
 export function Bio() {
   return (
     <div className="bg-white rounded-lg p-6 shadow-md mb-8">
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-4 gap-4">
         <div className="flex items-center gap-3">
           <BookHeart className="w-8 h-8 text-indigo-600" />
           <h2 className="text-xl font-semibold text-gray-900">About Me</h2>

--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -62,7 +62,115 @@ export function ResultsTable({ results }: ResultsTableProps) {
 
   return (
     <div className="bg-white rounded-lg shadow-md overflow-hidden">
-      <div className="overflow-x-auto">
+      {/* Mobile View */}
+      <div className="md:hidden">
+        <div className="bg-gray-50 px-4 py-3 border-b border-gray-200 flex gap-4">
+          <span className="text-xs font-medium text-gray-500 uppercase tracking-wider self-center">
+            Sort by:
+          </span>
+          <div className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+            <SortButton field="date">Date</SortButton>
+          </div>
+          <div className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+            <SortButton field="pace">Pace</SortButton>
+          </div>
+        </div>
+        <div className="divide-y divide-gray-200">
+          {sortedResults.map((result) => (
+            <div
+              key={`${result.date}-${result.name}`}
+              className="p-4 hover:bg-gray-50 space-y-3"
+            >
+              <div className="flex justify-between items-start">
+                <div>
+                  <div className="text-xs text-gray-500">
+                    {formatDate(result.date)}
+                  </div>
+                  <h3 className="font-bold text-gray-900">{result.name}</h3>
+                </div>
+                <span
+                  className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                    result.type === "full"
+                      ? "bg-indigo-100 text-indigo-800"
+                      : "bg-emerald-100 text-emerald-800"
+                  }`}
+                >
+                  {result.type === "full" ? "Marathon" : "Half Marathon"}
+                </span>
+              </div>
+
+              <div className="grid grid-cols-2 gap-4 text-sm">
+                <div>
+                  <div className="text-gray-500 uppercase text-[10px] font-bold">
+                    Location
+                  </div>
+                  <div className="flex items-center gap-1">
+                    {React.createElement(
+                      getCountryFlag(result.location.country),
+                      {
+                        className: "w-3 h-3",
+                      },
+                    )}
+                    <span>{result.location.name}</span>
+                  </div>
+                </div>
+                <div>
+                  <div className="text-gray-500 uppercase text-[10px] font-bold">
+                    Finish Time
+                  </div>
+                  <div className="font-semibold">
+                    {formatDuration(result.finishTime)}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-gray-500 uppercase text-[10px] font-bold">
+                    Avg Pace
+                  </div>
+                  <div>{calculatePace(result.finishTime, result.type)}/km</div>
+                </div>
+                <div>
+                  <div className="text-gray-500 uppercase text-[10px] font-bold">
+                    Weather
+                  </div>
+                  <div className="flex items-center gap-1">
+                    {React.createElement(
+                      getWeatherIcon(result.weather.condition),
+                      {
+                        className: "w-3 h-3 text-gray-400",
+                      },
+                    )}
+                    <span className="truncate">
+                      {result.weather.condition} ({result.weather.feelsLike}°C)
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              {result.specialMarks && result.specialMarks.length > 0 && (
+                <div className="flex flex-wrap gap-2 pt-2 border-t border-gray-100">
+                  {result.specialMarks.map((mark, index) => {
+                    const { icon: Icon, description } =
+                      convertSpecialMarkToIcon(mark);
+                    return (
+                      <div
+                        key={index}
+                        className="flex items-center gap-1 text-xs text-gray-500 bg-gray-50 px-2 py-1 rounded"
+                        title={description}
+                      >
+                        <Icon className="w-3.5 h-3.5" />
+                        <span>{description}</span>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Desktop View */}
+      <div className="hidden md:block overflow-x-auto">
         <table className="min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-50">
             <tr>

--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -61,10 +61,10 @@ export function ResultsTable({ results }: ResultsTableProps) {
   );
 
   return (
-    <div className="bg-white rounded-lg shadow-md overflow-hidden">
+    <div className="md:bg-white md:rounded-lg md:shadow-md md:overflow-hidden">
       {/* Mobile View */}
-      <div className="md:hidden">
-        <div className="bg-gray-50 px-4 py-3 border-b border-gray-200 flex gap-4">
+      <div className="md:hidden space-y-4">
+        <div className="bg-white px-4 py-3 rounded-lg shadow-md flex gap-4">
           <span className="text-xs font-medium text-gray-500 uppercase tracking-wider self-center">
             Sort by:
           </span>
@@ -75,11 +75,11 @@ export function ResultsTable({ results }: ResultsTableProps) {
             <SortButton field="pace">Pace</SortButton>
           </div>
         </div>
-        <div className="divide-y divide-gray-200">
+        <div className="space-y-4">
           {sortedResults.map((result) => (
             <div
               key={`${result.date}-${result.name}`}
-              className="p-4 hover:bg-gray-50 space-y-3"
+              className="bg-white rounded-lg shadow-md p-4 hover:bg-gray-50 space-y-3"
             >
               <div className="flex justify-between items-start">
                 <div>

--- a/src/components/StatsCard.tsx
+++ b/src/components/StatsCard.tsx
@@ -24,17 +24,21 @@ export function StatsCard({ stats }: StatsCardProps) {
               <Medal className="w-5 h-5" />
               <h3 className="font-medium">Best Times</h3>
             </div>
-            <p className="text-2xl font-bold text-gray-900 flex items-baseline gap-2">
-              <span>
-                {stats.bestFullTime ? formatDuration(stats.bestFullTime) : "-"}
-              </span>
-              <span className="text-sm text-gray-500">(full)</span>
+            <div className="text-2xl font-bold text-gray-900 flex flex-wrap items-baseline gap-x-2">
+              <div className="flex items-baseline gap-2">
+                <span>
+                  {stats.bestFullTime ? formatDuration(stats.bestFullTime) : "-"}
+                </span>
+                <span className="text-sm text-gray-500">(full)</span>
+              </div>
               <span className="text-gray-400">/</span>
-              <span>
-                {stats.bestHalfTime ? formatDuration(stats.bestHalfTime) : "-"}
-              </span>
-              <span className="text-sm text-gray-500">(half)</span>
-            </p>
+              <div className="flex items-baseline gap-2">
+                <span>
+                  {stats.bestHalfTime ? formatDuration(stats.bestHalfTime) : "-"}
+                </span>
+                <span className="text-sm text-gray-500">(half)</span>
+              </div>
+            </div>
           </div>
         </div>
 

--- a/src/components/UpcomingRaces.tsx
+++ b/src/components/UpcomingRaces.tsx
@@ -19,10 +19,10 @@ export function UpcomingRaces({ races }: UpcomingRacesProps) {
   });
 
   return (
-    <div className="bg-white rounded-lg shadow-md overflow-hidden">
+    <div className="md:bg-white md:rounded-lg md:shadow-md md:overflow-hidden">
       {/* Mobile View */}
-      <div className="md:hidden">
-        <div className="bg-gray-50 px-4 py-3 border-b border-gray-200 flex gap-4">
+      <div className="md:hidden space-y-4">
+        <div className="bg-white px-4 py-3 rounded-lg shadow-md flex gap-4">
           <span className="text-xs font-medium text-gray-500 uppercase tracking-wider self-center">
             Sort by:
           </span>
@@ -36,11 +36,11 @@ export function UpcomingRaces({ races }: UpcomingRacesProps) {
             <ArrowUpDown className="w-4 h-4" />
           </button>
         </div>
-        <div className="divide-y divide-gray-200">
+        <div className="space-y-4">
           {sortedRaces.map((race) => (
             <div
               key={`${race.date}-${race.name}`}
-              className="p-4 hover:bg-gray-50 space-y-3"
+              className="bg-white rounded-lg shadow-md p-4 hover:bg-gray-50 space-y-3"
             >
               <div className="flex justify-between items-start">
                 <div>

--- a/src/components/UpcomingRaces.tsx
+++ b/src/components/UpcomingRaces.tsx
@@ -20,7 +20,77 @@ export function UpcomingRaces({ races }: UpcomingRacesProps) {
 
   return (
     <div className="bg-white rounded-lg shadow-md overflow-hidden">
-      <div className="overflow-x-auto">
+      {/* Mobile View */}
+      <div className="md:hidden">
+        <div className="bg-gray-50 px-4 py-3 border-b border-gray-200 flex gap-4">
+          <span className="text-xs font-medium text-gray-500 uppercase tracking-wider self-center">
+            Sort by:
+          </span>
+          <button
+            onClick={() =>
+              setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"))
+            }
+            className="flex items-center gap-1 text-xs font-medium text-gray-500 uppercase tracking-wider hover:text-gray-700"
+          >
+            Date
+            <ArrowUpDown className="w-4 h-4" />
+          </button>
+        </div>
+        <div className="divide-y divide-gray-200">
+          {sortedRaces.map((race) => (
+            <div
+              key={`${race.date}-${race.name}`}
+              className="p-4 hover:bg-gray-50 space-y-3"
+            >
+              <div className="flex justify-between items-start">
+                <div>
+                  <div className="text-xs text-gray-500">
+                    {formatDate(race.date)}
+                  </div>
+                  <h3 className="font-bold text-gray-900">{race.name}</h3>
+                </div>
+                <span
+                  className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                    race.type === "full"
+                      ? "bg-indigo-100 text-indigo-800"
+                      : "bg-emerald-100 text-emerald-800"
+                  }`}
+                >
+                  {race.type === "full" ? "Marathon" : "Half Marathon"}
+                </span>
+              </div>
+
+              <div className="grid grid-cols-2 gap-4 text-sm">
+                <div>
+                  <div className="text-gray-500 uppercase text-[10px] font-bold">
+                    Location
+                  </div>
+                  <div className="flex items-center gap-1">
+                    {React.createElement(
+                      getCountryFlag(race.location.country),
+                      {
+                        className: "w-3 h-3",
+                      },
+                    )}
+                    <span>{race.location.name}</span>
+                  </div>
+                </div>
+                <div>
+                  <div className="text-gray-500 uppercase text-[10px] font-bold">
+                    Notes
+                  </div>
+                  <div className="text-gray-600 truncate">
+                    {race.notes || "-"}
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Desktop View */}
+      <div className="hidden md:block overflow-x-auto">
         <table className="min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-50">
             <tr>


### PR DESCRIPTION
This change addresses the horizontal overflow issue on small devices by introducing a responsive card-based layout for the race results and upcoming races tables. When the device width is below the Tailwind `md` breakpoint, the tables are hidden and replaced by a series of cards, each representing a race. This layout is much more usable on mobile. Additionally, I've added mobile-specific sorting controls and improved the responsiveness of the Bio and Stats components.

---
*PR created automatically by Jules for task [17408501210107106720](https://jules.google.com/task/17408501210107106720) started by @izackwu*