### PR TITLE
Fix stale half marathon best time

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,8 @@ import { marathonResults } from "./data/marathonResults";
 import { upcomingRaces } from "./data/upcomingRaces";
 import { bioContent } from "./data/bioContent";
 import { UpcomingRaces } from "./components/UpcomingRaces";
-import { MarathonStats } from "./types/marathon";
+import { MarathonStats, DurationString } from "./types/marathon";
+import { durationToSeconds } from "./utils/dateUtils";
 import { Footer } from "./components/Footer";
 
 function calculateStats(results: typeof marathonResults): MarathonStats {
@@ -20,22 +21,32 @@ function calculateStats(results: typeof marathonResults): MarathonStats {
 
   const nextRace = upcomingRaces.length > 0 ? upcomingRaces[0].date : undefined;
 
+  const bestHalfTime: DurationString | undefined =
+    halfMarathons.length > 0
+      ? halfMarathons.reduce(
+          (best, curr) => (curr.finishTime < best ? curr.finishTime : best),
+          halfMarathons[0].finishTime,
+        )
+      : undefined;
+
+  const bestFullTime: DurationString | undefined =
+    fullMarathons.length > 0
+      ? fullMarathons.reduce(
+          (best, curr) => (curr.finishTime < best ? curr.finishTime : best),
+          fullMarathons[0].finishTime,
+        )
+      : undefined;
+
+  // Hide half marathon best if it's stale (slower than half of full marathon best)
+  const isHalfTimeStale =
+    bestHalfTime &&
+    bestFullTime &&
+    durationToSeconds(bestHalfTime) > durationToSeconds(bestFullTime) / 2;
+
   return {
     totalRaces: results.length,
-    bestHalfTime:
-      halfMarathons.length > 0
-        ? halfMarathons.reduce(
-            (best, curr) => (curr.finishTime < best ? curr.finishTime : best),
-            halfMarathons[0].finishTime,
-          )
-        : undefined,
-    bestFullTime:
-      fullMarathons.length > 0
-        ? fullMarathons.reduce(
-            (best, curr) => (curr.finishTime < best ? curr.finishTime : best),
-            fullMarathons[0].finishTime,
-          )
-        : undefined,
+    bestHalfTime: isHalfTimeStale ? undefined : bestHalfTime,
+    bestFullTime,
     firstRaceDate: sortedResults[0].date,
     lastRaceDate: sortedResults[sortedResults.length - 1].date,
     uniqueCountries: new Set(results.map((r) => r.location.country)).size,

--- a/src/components/StatsCard.tsx
+++ b/src/components/StatsCard.tsx
@@ -31,13 +31,15 @@ export function StatsCard({ stats }: StatsCardProps) {
                 </span>
                 <span className="text-sm text-gray-500">(full)</span>
               </div>
-              <span className="text-gray-400">/</span>
-              <div className="flex items-baseline gap-2">
-                <span>
-                  {stats.bestHalfTime ? formatDuration(stats.bestHalfTime) : "-"}
-                </span>
-                <span className="text-sm text-gray-500">(half)</span>
-              </div>
+              {stats.bestHalfTime && (
+                <>
+                  <span className="text-gray-400">/</span>
+                  <div className="flex items-baseline gap-2">
+                    <span>{formatDuration(stats.bestHalfTime)}</span>
+                    <span className="text-sm text-gray-500">(half)</span>
+                  </div>
+                </>
+              )}
             </div>
           </div>
         </div>

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -42,6 +42,11 @@ export function createISODate(dateString: string): ISODateString {
   return dateString as ISODateString;
 }
 
+export function durationToSeconds(duration: DurationString): number {
+  const [hours, minutes, seconds] = duration.split(":").map(Number);
+  return hours * 3600 + minutes * 60 + seconds;
+}
+
 export function createDuration(duration: string): DurationString {
   try {
     parse(duration, "HH:mm:ss", new Date());


### PR DESCRIPTION
## Summary
- Hide half marathon PB from the stats card when it's slower than half of the full marathon PB, since that indicates the half time is outdated and no longer meaningful
- Added `durationToSeconds` helper to compare finish times numerically
- Updated `StatsCard` to conditionally render the half marathon section instead of showing a dash

## Test plan
- [x] Verify the half marathon best is hidden when it's stale (slower than half of full marathon best)
- [x] Verify the half marathon best still shows when it's faster than half of full marathon best
- [x] Verify layout looks clean with only the full marathon time displayed