### PR TITLE
feat: add Bay to Bay Running Festival to upcoming races

### DIFF
--- a/src/data/locations.ts
+++ b/src/data/locations.ts
@@ -12,6 +12,11 @@ export const locations: Record<string, Location> = {
     coordinates: { lat: -33.8698439, lng: 151.2082848 },
     country: "Australia",
   },
+  gosford: {
+    name: "Gosford",
+    coordinates: { lat: -33.424098, lng: 151.341148 },
+    country: "Australia",
+  },
   goldCoast: {
     name: "Gold Coast",
     coordinates: { lat: -28.0023731, lng: 153.4145987 },

--- a/src/data/upcomingRaces.ts
+++ b/src/data/upcomingRaces.ts
@@ -4,6 +4,16 @@ import { createISODate } from "../utils/dateUtils";
 
 export const upcomingRaces: UpcomingRace[] = [
   {
+    name: "Bay to Bay Running Festival",
+    date: createISODate("2026-06-14"),
+    type: "half",
+    location: {
+      name: locations.gosford.name,
+      country: locations.gosford.country,
+    },
+    notes: "Tune-up race before Gold Coast",
+  },
+  {
     name: "Gold Coast Marathon",
     date: createISODate("2026-07-05"),
     type: "full",


### PR DESCRIPTION
## Summary
- Adds Bay to Bay Running Festival (half marathon, 2026-06-14) in Gosford as a tune-up race before Gold Coast.
- Adds Gosford coordinates to `locations.ts`.

## Test plan
- [x] `npm run build` passes
- [x] Verify the race appears in the upcoming races view