### PR TITLE
Fix truncation of upcoming race notes on mobile

### DIFF
--- a/src/components/UpcomingRaces.tsx
+++ b/src/components/UpcomingRaces.tsx
@@ -79,7 +79,7 @@ export function UpcomingRaces({ races }: UpcomingRacesProps) {
                   <div className="text-muted uppercase text-label">
                     Notes
                   </div>
-                  <div className="text-body truncate">
+                  <div className="text-body">
                     {race.notes || "-"}
                   </div>
                 </div>


### PR DESCRIPTION
Fixed the issue where notes for upcoming races were being truncated on mobile devices.

### Changes:
- Modified `src/components/UpcomingRaces.tsx` to remove the `truncate` class from the notes container in the mobile view.

### Verification:
- Created a Playwright script to simulate a mobile viewport and verified that long notes now wrap correctly.
- Confirmed with a screenshot that the text is no longer truncated.
- Ran `npm run build` to ensure no regressions.

---
*PR created automatically by Jules for task [1715216530858634421](https://jules.google.com/task/1715216530858634421) started by @izackwu*