### PR TITLE
feat: add Bay to Bay half marathon result

### DIFF
--- a/src/data/marathonResults.ts
+++ b/src/data/marathonResults.ts
@@ -204,7 +204,7 @@ export const marathonResults: MarathonResult[] = [
     finishTime: createDuration("01:29:34"),
     location: locations.gosford,
     weather: {
-      feelsLike: 15,
+      feelsLike: 18,
       condition: "Cloudy",
     },
     specialMarks: [{ type: "PB" }],

--- a/src/data/marathonResults.ts
+++ b/src/data/marathonResults.ts
@@ -207,11 +207,6 @@ export const marathonResults: MarathonResult[] = [
       feelsLike: 15,
       condition: "Cloudy",
     },
-    specialMarks: [
-      {
-        type: "PB",
-        description: "New half marathon Personal Best! Big breakthrough.",
-      },
-    ],
+    specialMarks: [{ type: "PB" }],
   },
 ];

--- a/src/data/marathonResults.ts
+++ b/src/data/marathonResults.ts
@@ -197,4 +197,21 @@ export const marathonResults: MarathonResult[] = [
       },
     ],
   },
+  {
+    name: "Bay to Bay Running Festival",
+    date: createISODate("2026-06-14"),
+    type: "half",
+    finishTime: createDuration("01:29:34"),
+    location: locations.gosford,
+    weather: {
+      feelsLike: 15,
+      condition: "Cloudy",
+    },
+    specialMarks: [
+      {
+        type: "PB",
+        description: "New half marathon Personal Best! Big breakthrough.",
+      },
+    ],
+  },
 ];

--- a/src/data/upcomingRaces.ts
+++ b/src/data/upcomingRaces.ts
@@ -4,16 +4,6 @@ import { createISODate } from "../utils/dateUtils";
 
 export const upcomingRaces: UpcomingRace[] = [
   {
-    name: "Bay to Bay Running Festival",
-    date: createISODate("2026-06-14"),
-    type: "half",
-    location: {
-      name: locations.gosford.name,
-      country: locations.gosford.country,
-    },
-    notes: "Tune-up race before Gold Coast",
-  },
-  {
     name: "Gold Coast Marathon",
     date: createISODate("2026-07-05"),
     type: "full",


### PR DESCRIPTION
## Summary

Records the **Bay to Bay Running Festival** half marathon (Gosford, NSW) run on 2026-06-14 with a finish time of **1:29:34** — a new half marathon personal best (previous best: 1:44:56 at the 2XU Compression Run).

## Changes

- Added the race result to `src/data/marathonResults.ts` with a `PB` special mark
- Removed the now-completed race from `src/data/upcomingRaces.ts`
- Reused the existing `locations.gosford` coordinates

## Weather

- **Feels like 18°C, Cloudy** (per the runner; felt warmer than forecast)
- Gosford forecast for the morning: low 14°C / high 21°C, cloudy with showers developing later. Sources: BOM East Gosford, Weatherzone Gosford.

## Verification

- `npm run build` passes (includes type-check)
- The 6 `npm run lint` errors are pre-existing in `MapView.tsx` and unrelated to this change

https://claude.ai/code/session_01TUhSZP6nkG5Thgdb8YFL6B