### PR TITLE
fix(MapView): replace `any` with geojson/topojson types

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from "react";
 import * as d3 from "d3";
 import * as topojson from "topojson-client";
+import type { Feature, GeometryObject } from "geojson";
+import type { GeometryCollection, Topology } from "topojson-specification";
 import countries from "i18n-iso-countries";
 import enLocale from "i18n-iso-countries/langs/en.json";
 import { MarathonResult } from "../types/marathon";
@@ -192,17 +194,21 @@ export function MapView({ results }: MapViewProps) {
       .style("z-index", "10");
 
     // Load world data and render
-    d3.json(
+    d3.json<Topology>(
       "https://cdn.jsdelivr.net/npm/world-atlas@2/countries-50m.json",
-    ).then((world: any) => {
-      const countries_geo = topojson.feature(world, world.objects.countries);
+    ).then((world) => {
+      if (!world) return;
+      const countries_geo = topojson.feature(
+        world,
+        world.objects.countries as GeometryCollection,
+      );
 
       gLand
         .selectAll("path")
-        .data((countries_geo as any).features)
+        .data(countries_geo.features)
         .enter()
         .append("path")
-        .attr("d", path as any)
+        .attr("d", path)
         .attr("fill", COLOR_LAND)
         .attr("stroke", COLOR_LAND_STROKE)
         .attr("stroke-width", 0.5);
@@ -210,8 +216,8 @@ export function MapView({ results }: MapViewProps) {
       // Country labels — geographic centroid from TopoJSON, with fallback
       // to race location coordinates for small territories (HK, Singapore)
       // Group features by country, then use the largest polygon for centroid
-      const countryFeatures = (countries_geo as any).features as any[];
-      const featuresByCountry = new Map<string, any[]>();
+      const countryFeatures = countries_geo.features;
+      const featuresByCountry = new Map<string, Feature<GeometryObject>[]>();
 
       for (const feature of countryFeatures) {
         const numericId = feature.id?.toString();


### PR DESCRIPTION
## Problem

`npm run lint` reported 6 pre-existing `@typescript-eslint/no-explicit-any` errors in `src/components/MapView.tsx`, all in the world-map rendering block where the TopoJSON/GeoJSON values were typed as `any`.

## Fix

Replaced the `any` usages with the proper types from the already-installed `geojson` and `topojson-specification` packages:

- `d3.json<Topology>(...)` types the loaded world atlas, with a guard for the `undefined` case d3 allows.
- `world.objects.countries` is narrowed to `GeometryCollection` for `topojson.feature(...)`, whose return is a typed `FeatureCollection` — so `.features` no longer needs casting.
- `path` is passed directly to `.attr("d", ...)` (a GeoJSON `Feature<GeometryObject>` is assignable to d3-geo's `GeoPermissibleObjects`).
- `featuresByCountry` is a `Map<string, Feature<GeometryObject>[]>`.

No runtime behavior changes — this is types only.

## Testing

- `npm run build` (includes type-check) passes.
- `npm run lint` is now clean (0 errors).

https://claude.ai/code/session_0141xwD18Gs625P9GrKeqAZD

---
_Generated by [Claude Code](https://claude.ai/code/session_0141xwD18Gs625P9GrKeqAZD)_